### PR TITLE
Remove superfluous /apps directory from index.theme

### DIFF
--- a/adwaita-xfce/index.theme
+++ b/adwaita-xfce/index.theme
@@ -4,7 +4,7 @@ Comment=Adwaita icon theme extension for Xfce
 Inherits=Adwaita
 Example=folder
 
-Directories=16x16/devices,16x16/status,22x22/status,24x24/devices,24x24/status,32x32/devices,32x32/status,48x48/apps,48x48/devices,48x48/status,/apps,scalable/apps,scalable/devices,scalable/status,scalable/actions,scalable/categories
+Directories=16x16/devices,16x16/status,22x22/status,24x24/devices,24x24/status,32x32/devices,32x32/status,48x48/apps,48x48/devices,48x48/status,scalable/apps,scalable/devices,scalable/status,scalable/actions,scalable/categories
 
 
 [16x16/devices]


### PR DESCRIPTION
index.theme referred to a non-existent /apps subdirectory, causing warnings like:

    (zenity:9387): Gtk-WARNING **: 23:22:38.069: Theme directory /apps of theme adwaita-xfce has no size field

when running commands like

    zenity --info --text "foo"

So remove `/apps` from the `Directories` line.